### PR TITLE
6桁以上の数値を受信すると下位2桁が表示されてしまう問題の修正

### DIFF
--- a/usb_7seg/usb_7seg.ino
+++ b/usb_7seg/usb_7seg.ino
@@ -92,6 +92,9 @@ void loop() {
         lc.clearDisplay(0);
         suc_state = 0;
         suc_correct_flg = 0;
+        while( Serial.available() ){
+          tmp = Serial.read();
+        }
       }
     }
     break;


### PR DESCRIPTION
下記バグを修正した
https://github.com/realglobe-Inc/usb_7seg/issues/13

以下上記issueの転載
ex.1)意図した動作("_"は消灯セグメントを表す)
123→[_123]
1234→[1234]
12345→[____]
1234567890→[____]
ex.2)意図しない動作
123456→[___6]
123456789→[6789]